### PR TITLE
Add message integrity checks to the headers

### DIFF
--- a/src/ServiceBus.MessageEncryption.Tests/MessagePayloadEncryptionPluginShould.cs
+++ b/src/ServiceBus.MessageEncryption.Tests/MessagePayloadEncryptionPluginShould.cs
@@ -1,7 +1,10 @@
 using FluentAssertions;
 using Microsoft.Azure.ServiceBus;
 using NUnit.Framework;
+using ServiceBus.MessageEncryption.Providers;
 using ServiceBus.MessageEncryption.Tests.TestDoubles;
+using System;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -9,12 +12,14 @@ namespace ServiceBus.MessageEncryption.Tests
 {
     public class MessagePayloadEncryptionPluginShould
     {
-        private MessagePayloadEncryptionPlugin plugin;
+        private ICryptographyProvider fakeCryptographyProvider;
+        private const string integrityCheckKeyProperty = "int-check-key";
+        private const string integrityCheckStatusProperty = "int-check-status";
 
         [SetUp()]
         public void Setup()
         {
-            plugin = new MessagePayloadEncryptionPlugin(new FakeCryptographyProvider());
+            fakeCryptographyProvider = new FakeCryptographyProvider();
         }
 
         [Test]
@@ -23,6 +28,8 @@ namespace ServiceBus.MessageEncryption.Tests
             //Arrange
             const string inputMessagePayload = "MESSAGE_PAYLOAD";
             Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes(inputMessagePayload));
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider);
 
             //Act
             var result = await plugin.BeforeMessageSend(serviceBusMessage);
@@ -39,12 +46,119 @@ namespace ServiceBus.MessageEncryption.Tests
             const string inputMessagePayload = "MESSAGE_PAYLOAD-ENCRYPTED";
             Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes(inputMessagePayload));
 
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider);
+
             //Act
             var result = await plugin.AfterMessageReceive(serviceBusMessage);
 
             //Assert
             var actualMessagePayload = Encoding.UTF8.GetString(result.Body);
             actualMessagePayload.Should().Be("MESSAGE_PAYLOAD");
+        }
+
+        [Test]
+        public async Task Add_IntegrityCheck_Key_To_User_Properties_Before_Sending_The_Message()
+        {
+            //Arrange
+            var messagePayloadBytes = Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD");
+            Message serviceBusMessage = new Message(messagePayloadBytes);
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider);
+
+            //Act
+            var result = await plugin.BeforeMessageSend(serviceBusMessage);
+
+            //Assert
+            result.UserProperties.ContainsKey(integrityCheckKeyProperty).Should().BeTrue();
+            result.UserProperties[integrityCheckKeyProperty].ToString().Should().Be(GetMd5Hash(messagePayloadBytes));
+        }
+
+        [Test]
+        public async Task Add_IntegrityCheck_Status_To_User_Properties_After_Receiving_The_Message()
+        {
+            //Arrange
+            Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD"));
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider);
+
+            //Act
+            var result = await plugin.BeforeMessageSend(serviceBusMessage);
+            result = await plugin.AfterMessageReceive(result);
+
+            //Assert
+            result.UserProperties.ContainsKey(integrityCheckStatusProperty).Should().BeTrue();
+            result.UserProperties[integrityCheckStatusProperty].ToString().Should().Be("Pass");
+        }
+
+        [Test]
+        public async Task Allow_Overriding_User_Property_Name_For_Integrity_Check_Key()
+        {
+            //Arrange
+            Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD"));
+
+            const string keyName = "intcheckkey";
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider, intCheckKeyPropertyName: keyName);
+
+            //Act
+            var result = await plugin.BeforeMessageSend(serviceBusMessage);
+
+            //Assert
+            result.UserProperties.ContainsKey(integrityCheckKeyProperty).Should().BeFalse();
+            result.UserProperties.ContainsKey(keyName).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Allow_Overriding_User_Property_Name_For_Integrity_Check_Status()
+        {
+            //Arrange
+            Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD"));
+
+            const string keyName = "intcheckstatus";
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider, intCheckStatusPropertyName: keyName);
+
+            //Act
+            var result = await plugin.BeforeMessageSend(serviceBusMessage);
+            result = await plugin.AfterMessageReceive(result);
+
+            //Assert
+            result.UserProperties.ContainsKey(integrityCheckStatusProperty).Should().BeFalse();
+            result.UserProperties.ContainsKey(keyName).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Throw_NullReferenceException_When_IntegrationCheckKey_Is_Missing_And_ThrowExeption_Flag_Is_True()
+        {
+            //Arrange
+            Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD"));
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider, throwExceptionWhenMissingProperties: true);
+
+            //Act
+
+            Func<Task<Message>> func = async () => await plugin.AfterMessageReceive(serviceBusMessage);
+
+            await func.Should().ThrowExactlyAsync<NullReferenceException>();
+        }
+
+        [Test]
+        public async Task Not_Add_IntegrityCheck_Status_To_User_Properties_When_IntegrationCheckKey_Is_Missing_And_ThrowExeption_Flag_Is_False()
+        {
+            //Arrange
+            Message serviceBusMessage = new Message(Encoding.UTF8.GetBytes("MESSAGE_PAYLOAD"));
+
+            var plugin = new MessagePayloadEncryptionPlugin(fakeCryptographyProvider);
+
+            //Act
+            var result = await plugin.AfterMessageReceive(serviceBusMessage);
+
+            result.UserProperties.ContainsKey(integrityCheckStatusProperty).Should().BeFalse();
+        }
+
+        private string GetMd5Hash(byte[] bytes)
+        {
+            return Encoding.UTF8.GetString(MD5.Create().ComputeHash(bytes));
         }
     }
 }

--- a/src/ServiceBus.MessageEncryption/MessagePluginExtensions.cs
+++ b/src/ServiceBus.MessageEncryption/MessagePluginExtensions.cs
@@ -3,13 +3,15 @@ using ServiceBus.MessageEncryption.Providers;
 
 namespace ServiceBus.MessageEncryption
 {
-    public static class MessagePayloadEncryptionPluginExtensions
+    public static class MessagePluginExtensions
     {
-        public static void WithRijndaelManagedEncryption(this IClientEntity clientEntity, string cryptoKey, string initVectorKey)
+        public static IClientEntity EnableRijndaelManagedEncryption(this IClientEntity clientEntity, string cryptoKey, string initVectorKey)
         {
             ICryptographyProvider provider = new RijndaelManagedCryptographyProvider(cryptoKey, initVectorKey);
 
             clientEntity.RegisterPlugin(new MessagePayloadEncryptionPlugin(provider));
+
+            return clientEntity;
         }
     }
 }

--- a/src/ServiceBus.MessageEncryption/ServiceBus.MessageEncryption.csproj
+++ b/src/ServiceBus.MessageEncryption/ServiceBus.MessageEncryption.csproj
@@ -5,11 +5,11 @@
     <AssemblyName>ServiceBus.MessageEncryption</AssemblyName>
     <Version>1.0.0.0</Version>
     <Authors>Vighneshwar Madas</Authors>
-    <Product>Azure ServiceBus MessageEncryption Plugin</Product>
-    <Description>Azure ServiceBus MessageEncryption Plugin</Description>
+    <Product>Azure ServiceBus Message Encryption Plugin</Product>
+    <Description>Azure ServiceBus Message Encryption Plugin</Description>
     <Copyright>© Vighneshwar Madas 2020</Copyright>
-    <PackageProjectUrl>https://github.com/iamvighnesh/azure-servicesbus-message-keyvault-encryption</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/iamvighnesh/azure-servicesbus-message-keyvault-encryption</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/iamvighnesh/azure-servicesbus-message-encryption-plugin</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/iamvighnesh/azure-servicesbus-message-encryption-plugin</RepositoryUrl>
     <RepositoryType>GitHub</RepositoryType>
     <NeutralLanguage>en-GB</NeutralLanguage>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
- Enable message payload integrity checks using MD5 checksum.
- This allows the consumers of the message check if the message payload was intercepted by anyone or not.